### PR TITLE
Path included instead of exactly.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adp-next",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adp-next",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "ADP Next",
   "main": "src/content-script.js",
   "scripts": {

--- a/src/app/toolbar/toolbar.ts
+++ b/src/app/toolbar/toolbar.ts
@@ -2,7 +2,7 @@ import './toolbar.style';
 import { whenElementReady } from '../shared/dom.util';
 import { holidaysUtil } from '../shared/holidays.util';
 
-export const myTimecardPath = '#Myself_ttd_MyselfTabTimecardsAttendanceSchCategoryTLMWebMyTimecard/MyselfTabTimecardsAttendanceSchCategoryTLMWebMyTimecard';
+export const myTimecardPath = 'Myself_ttd_MyselfTabTimecardsAttendanceSchCategoryTLMWebMyTimecard/MyselfTabTimecardsAttendanceSchCategoryTLMWebMyTimecard';
 
 
 function addToolbar() {
@@ -134,7 +134,7 @@ export function checkToolbar() {
   const path = location.hash;
   const toolbar = document.querySelector('.adp-next');
 
-  if (path === myTimecardPath) {
+  if (path.includes(myTimecardPath)) {
     if (!toolbar) {
       whenElementReady('TimecardManager', () => {
         addToolbar();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,7 @@
     ]
   },
   "description": "Add some useful features to ADP",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "permissions": [
     "storage"
   ],


### PR DESCRIPTION
This change was required because the hash tag was changed again. With the include method and only the name of the selector being compared as part of the hash tag, the initialization of the script is more accurate. 